### PR TITLE
Rearrange disconnect and state transition

### DIFF
--- a/src/fsmpico.c
+++ b/src/fsmpico.c
@@ -388,8 +388,7 @@ void fsmpico_read(FsmPico * fsmpico, char const * data, size_t length) {
 		result = readMessageStatus(fsmpico, dataread, receivedExtraData, &status);
 		if (result) {
 			fsmpico->comms->authenticated((int) status, fsmpico->user_data);
-			fsmpico->comms->disconnect(fsmpico->user_data);
-            
+
 			switch (status) {
 			case MESSAGESTATUS_OK_DONE:
 				stateTransition(fsmpico, FSMPICOSTATE_FIN);
@@ -401,6 +400,7 @@ void fsmpico_read(FsmPico * fsmpico, char const * data, size_t length) {
 				stateTransition(fsmpico, FSMPICOSTATE_ERROR);
 				break;
 			}
+			fsmpico->comms->disconnect(fsmpico->user_data);
 		}
 		break;
 	case FSMPICOSTATE_CONTSTARTSERVICE:


### PR DESCRIPTION
Closes #15 

This avoids the state machine being in the incorrect state in the
case where the 'disconnected' notification happens immediately
(that is, it happens *inside* the disconnect function call, without
entering the event loop).

If the FSM is in the wrong state, an error will be triggered, rather
than the intended reconnect. This change ensures the FSM will be in
the right state, by setting the state up before the disconnect is
requested.